### PR TITLE
Updated Static Publisher dependency to remove forked version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,6 @@
 	"require": {
 		"silverstripe/framework": "~3.1",
 		"silverstripe/cms": "~3.1",
-		"silverstripe/staticpublishqueue": "2.0.x-dev"
-	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/stojg/silverstripe-staticpublishqueue.git"
-		}
-	]
+		"silverstripe/staticpublishqueue": "*@stable"
+	}
 }


### PR DESCRIPTION
It is no longer necessary to use Stig's forked version of Static Publisher, as all of the modifications present in the fork have been merged back into the main repository. Instead, I have changed the dependency to always use the latest stable version.
